### PR TITLE
Remove .cargo/config

### DIFF
--- a/server/.cargo/config
+++ b/server/.cargo/config
@@ -1,2 +1,0 @@
-[registry]
-index = "https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
This just repeats the defaults, and as such doesn't need to exist.